### PR TITLE
Set videoLoaded to true immediately if loaded before the canplaythrou…

### DIFF
--- a/concerns/loads-assets.coffee
+++ b/concerns/loads-assets.coffee
@@ -18,8 +18,11 @@ export default
 		imageLoaded: false
 		videoLoaded: false
 
-	# Set loaded to true immediately if loaded before the load event fires
-	mounted: -> @imageLoaded = true if @$refs?.image?.complete
+	mounted: -> 
+		# Set loaded to true immediately if loaded before the load event fires
+		@imageLoaded = true if @$refs?.image?.complete
+		# Set loaded to true immediately if loaded before the canplaythrough event fires
+		@videoLoaded = true if @$refs?.video?.readyState > 3
 
 	computed:
 


### PR DESCRIPTION
Use the [readystate](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState) property to check if the video loaded before the canplaythrough event fires.  Solves an issue I found where `videoLoaded` never gets set to true in some instances in local development, because the `canplaythrough` event was not getting captured by Vue.