### PR TITLE
fix image loading conflict with video

### DIFF
--- a/concerns/supports-images.coffee
+++ b/concerns/supports-images.coffee
@@ -12,14 +12,12 @@ export default
 
 		# Determines whether the image should be shown via v-show
 		showImage: -> switch
+			# Image has finished loading
+			when @imageLoaded then return true
 
 			# Switch to video instance
 			when @videoLoaded then false
 
 			# Render immediately if no transition and no video.  If there is a video,
 			# the video should be the one to be immediately rendered.
-			when !@transition and !@video then true
-
-			# Image has finished loading
-			when @imageLoaded then true
-
+			when !@transition and !@video then return true

--- a/index.js
+++ b/index.js
@@ -632,15 +632,15 @@ Logic related rendering images
     // Determines whether the image should be shown via v-show
     showImage: function showImage() {
       switch (false) {
+        // Image has finished loading
+        case !this.imageLoaded:
+          return true;
         // Switch to video instance
+
         case !this.videoLoaded:
           return false;
 
         case !(!this.transition && !this.video):
-          return true;
-        // Image has finished loading
-
-        case !this.imageLoaded:
           return true;
       }
     }


### PR DESCRIPTION
The order of the switch statement in `supports-images.coffee` was leading to conflicts while rendering a visual that had potential to have either video or image. Reordered the switch and made a return if an image was found to be loaded.