### PR TITLE
adding the ability to maintain the placeholder color if desired

### DIFF
--- a/concerns/loads-assets.coffee
+++ b/concerns/loads-assets.coffee
@@ -9,6 +9,7 @@ export default
 			default: true
 		lazyload: Boolean
 		placeholderColor: String
+		maintainPlaceholder: Boolean
 		transition:
 			type: String
 			default: 'vv-fade'

--- a/index.js
+++ b/index.js
@@ -130,13 +130,19 @@ var render = function() {
           })
         : _vm._e(),
       _c("transition", { attrs: { name: _vm.transition } }, [
-        _vm.placeholderColor && !_vm.showImage
+        _vm.placeholderColor && !_vm.showImage && !_vm.maintainPlaceholder
           ? _c("div", {
               staticClass: "vv-placeholder",
               style: { backgroundColor: _vm.placeholderColor }
             })
           : _vm._e()
       ]),
+      _vm.placeholderColor && !_vm.showImage && _vm.maintainPlaceholder
+        ? _c("div", {
+            staticClass: "vv-placeholder",
+            style: { backgroundColor: _vm.placeholderColor }
+          })
+        : _vm._e(),
       _vm.image && _vm.shouldLoad
         ? _c(
             "div",
@@ -374,6 +380,7 @@ Logic related to loading assets
     },
     lazyload: Boolean,
     placeholderColor: String,
+    maintainPlaceholder: Boolean,
     transition: {
       type: String,
       default: 'vv-fade'

--- a/index.vue
+++ b/index.vue
@@ -16,8 +16,13 @@
 	//- Show a placeholder shape until an asset is loaded
 	transition(:name='transition')
 		.vv-placeholder(
-			v-if='placeholderColor && !showImage'
+			v-if='placeholderColor && !showImage && !maintainPlaceholder'
 			:style='{ backgroundColor: placeholderColor }')
+
+	//- This keeps the placeholder present
+	.vv-placeholder(
+		v-if='placeholderColor && !showImage && maintainPlaceholder'
+		:style='{ backgroundColor: placeholderColor }')
 
 	//- Image asset
 	//- The wrapper constainer is needed for the object-fit polyfill


### PR DESCRIPTION
@weotch I added this, which was to solve [this issue on Clif ](url)https://app.asana.com/0/1199094171432804/1200386443419587/f

Problem: 
- when the image is loaded, the check for `showImage` does 2 things
- 1. it fades in the image
- 2. it fades out the placeholder element
- Since both of those have a transition, you see the drop-shadow element for a second as the transition is happening on both
- My idea for the fix is to pass a prop called `maintainPlaceholder` which doesn't wrap `.vv-placeholder` in the transition

If you have an opinion on a better way to go about this, or at least how to clean up me needing to render the `.vv-placeholder` element twice, then let me know

This works locally on clif for me, and passing `maintainPlaceholder` as a prop lets me control this on a component-by-component basis, because I don't want this to happen on say, transparent pngs